### PR TITLE
Remove unnecessary `setup()` parameters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-try:
-    from setuptools import setup
-except ImportError:
-    raise
-#     from distutils.core import setup
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 
@@ -55,11 +51,9 @@ setup(
     packages=[
         'pyethapp',
     ],
-    package_dir={'pyethapp': 'pyethapp'},
     package_data={
         'pyethapp': ['data/*.json']
     },
-    include_package_data=True,
     license="BSD",
     zip_safe=False,
     keywords='pyethapp',


### PR DESCRIPTION
`include_package_data` and `package_data` are incompatible; see: https://bitbucket.org/pypa/setuptools/issues/287/ignores-package-data-if-package_dir-is

Fixes: ethereum/pyethapp#59
Fixes: HydraChain/hydrachain#4