### PR TITLE
Bootstrap nodes in profiles

### DIFF
--- a/pyethapp/profiles.py
+++ b/pyethapp/profiles.py
@@ -1,5 +1,4 @@
 from os import path
-from ethereum.utils import denoms
 
 
 DEFAULT_PROFILE = 'frontier'
@@ -11,7 +10,31 @@ PROFILES = {
         'eth': {
             'network_id': 1,
             'genesis': path.join(genesisdata_dir, 'genesis_frontier.json'),
-            'genesis_hash': 'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'
+            'genesis_hash': 'd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3',
+            'discovery': {
+                'bootstrap_nodes': [
+                    (  # C++
+                        'enode://487611428e6c99a11a9795a6abe7b529e81315ca6aad66e2a2fc76e3adf263fa'
+                        'ba0d35466c2f8f68d561dbefa8878d4df5f1f2ddb1fbeab7f42ffb8cd328bd4a'
+                        '@5.1.83.226:30303'
+                    ),
+                    (  # Go
+                        'enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef2'
+                        '9b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c'
+                        '@52.16.188.185:30303'
+                    ),
+                    (  # Go 2
+                        'enode://de471bccee3d042261d52e9bff31458daecc406142b401d4cd848f677479f731'
+                        '04b9fdeb090af9583d3391b7f10cb2ba9e26865dd5fca4fcdc0fb1e3b723c786'
+                        '@54.94.239.50:30303'
+                    ),
+                    (  # Python
+                        'enode://2676755dd8477ad3beea32b4e5a144fa10444b70dfa3e05effb0fdfa75683ebd'
+                        '4f75709e1f8126cb5317c5a35cae823d503744e790a3a038ae5dd60f51ee9101'
+                        '@144.76.62.101:30303'
+                    )
+                ]
+            }
         }
     },
     'morden': {

--- a/pyethapp/profiles.py
+++ b/pyethapp/profiles.py
@@ -18,15 +18,19 @@ PROFILES = {
         'eth': {
             'network_id': 2,
             'genesis': path.join(genesisdata_dir, 'genesis_morden.json'),
-        'genesis_hash': '0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303',
-        'block': {
-            'ACCOUNT_INITIAL_NONCE': 2 ** 20
-        }
-    },
-    'discovery': {
-        'bootstrap_nodes': [
-            'enode://e58d5e26b3b630496ec640f2530f3e7fa8a8c7dfe79d9e9c4aac80e3730132b869c852d3125204ab35bb1b1951f6f2d40996c1034fd8c5a69b383ee337f02ddc@92.51.165.126:30303'
-        ]
+            'genesis_hash': '0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303',
+            'block': {
+                'ACCOUNT_INITIAL_NONCE': 2 ** 20
+            },
+            'discovery': {
+                'bootstrap_nodes': [
+                    (
+                        'enode://e58d5e26b3b630496ec640f2530f3e7fa8a8c7dfe79d9e9c4aac80e3730132b8'
+                        '69c852d3125204ab35bb1b1951f6f2d40996c1034fd8c5a69b383ee337f02ddc'
+                        '@92.51.165.126:30303'
+                    )
+                ]
+            }
+        },
     }
-}
 }

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires_replacements = {
 install_requires = [install_requires_replacements.get(r, r) for r in install_requires]
 test_requirements = ['ethereum-serpent>=1.8.1']
 
-version = '1.0.8'  # preserve format, this is read from __init__.py
+version = '1.0.9'  # preserve format, this is read from __init__.py
 
 setup(
     name='pyethapp',


### PR DESCRIPTION
The bootstrap nodes are now defined in the "profile" for both current networks.

This allows us to remove them from pydevp2p's default config (where they don't really belong).
