### PR TITLE
IPC RPC for Mist #44

### DIFF
--- a/pyethapp/app.py
+++ b/pyethapp/app.py
@@ -24,7 +24,7 @@ from ethereum.blocks import Block
 import ethereum.slogging as slogging
 import config as konfig
 from db_service import DBService
-from jsonrpc import JSONRPCServer
+from jsonrpc import JSONRPCServer, IPCRPCServer
 from pow_service import PoWService
 from accounts import AccountsService, Account
 from pyethapp import __version__
@@ -36,7 +36,7 @@ log = slogging.get_logger('app')
 
 
 services = [DBService, AccountsService, NodeDiscovery, PeerManager, ChainService, PoWService,
-            JSONRPCServer, Console]
+            JSONRPCServer, IPCRPCServer, Console]
 
 
 class EthApp(BaseApp):

--- a/pyethapp/ipc_rpc.py
+++ b/pyethapp/ipc_rpc.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Derived from https://groups.google.com/d/topic/gevent/5__B9hOup38/discussion
+"""
+import _socket
+import os
+import pwd
+from gevent.server import StreamServer
+import tempfile
+
+
+def unlink(path):
+    from errno import ENOENT
+    try:
+        os.unlink(path)
+    except OSError, ex:
+        if ex.errno != ENOENT:
+            raise
+
+
+def link(src, dest):
+    from errno import ENOENT
+    try:
+        os.link(src, dest)
+    except OSError, ex:
+        if ex.errno != ENOENT:
+            raise
+
+
+def bind_unix_listener(path, backlog=50, user=None):
+    pid = os.getpid()
+    tempname = '%s.%s.tmp' % (path, pid)
+    backname = '%s.%s.bak' % (path, pid)
+    unlink(tempname)
+    unlink(backname)
+    link(path, backname)
+    try:
+        sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        sock.setblocking(0)
+        sock.bind(tempname)
+        try:
+
+            if user is not None:
+                user = pwd.getpwnam(user)
+                os.chown(tempname, user.pw_uid, user.pw_gid)
+                os.chmod(tempname, 0600)
+            sock.listen(backlog)
+            try:
+                os.rename(tempname, path)
+            except:
+                os.rename(backname, path)
+                backname = None
+                raise
+            tempname = None
+            return sock
+        finally:
+            if tempname is not None:
+                unlink(tempname)
+    finally:
+        if backname is not None:
+            unlink(backname)
+
+
+def handle(socket, address):
+    print socket, address
+    print socket.recv(4096)
+    socket.sendall('pong\n')
+
+
+def serve(sock, handler=handle):
+    StreamServer(sock, handler).serve_forever()
+
+if __name__ == "__main__":
+    path = os.path.join(tempfile.gettempdir(), "echo.ipc")
+    print "Starting echo sever..."
+    print "Test it with:\n\techo 'ping'| socat - {}".format(path)
+    serve(bind_unix_listener(path))

--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -775,6 +775,19 @@ class Chain(Subdispatcher):
         return str(ETHProtocol.version)
 
     @public
+    def syncing(self):
+        if not self.chain.is_syncing:
+            return False
+        else:
+            synctask = self.chain.synchronizer.synctask
+            result = dict(
+                startingBlock=synctask.start_block_number,
+                currentBlock=self.chain.chain.head.number,
+                highestBlock=synctask.end_block_number,
+            )
+            return {k: quantity_encoder(v) for k, v in result.items()}
+
+    @public
     @encode_res(quantity_encoder)
     def blockNumber(self):
         return self.chain.chain.head.number

--- a/rpc_methods
+++ b/rpc_methods
@@ -21,7 +21,7 @@ Checklist for implemented JSON RPC methods
 [x] eth_getUncleCountByBlockNumber
 [x] eth_getCode
 [ ] eth_sign
-[ ] eth_syncing
+[x] eth_syncing
 [x] eth_sendTransaction
 [x] eth_call
 [ ] eth_estimateGas

--- a/rpc_methods
+++ b/rpc_methods
@@ -21,6 +21,7 @@ Checklist for implemented JSON RPC methods
 [x] eth_getUncleCountByBlockNumber
 [x] eth_getCode
 [ ] eth_sign
+[ ] eth_syncing
 [x] eth_sendTransaction
 [x] eth_call
 [ ] eth_estimateGas


### PR DESCRIPTION
This adds a new (unix domain sockets-based) IPC-RPC connector in order to connect with mist.

For full mist-interop, we need to make sure that we comply with the test from https://github.com/ethereum/rpc-tests

link to issue: #44 
