### PR TITLE
Unable to create a contract using pyethapp v1.2.1

### DIFF
--- a/pyethapp/console_service.py
+++ b/pyethapp/console_service.py
@@ -191,7 +191,6 @@ class Console(BaseService):
             def latest(this):
                 return this.chain.head
 
-
             def transact(this, to, value=0, data='', sender=None,
                          startgas=25000, gasprice=60 * denoms.shannon):
                 sender = normalize_address(sender or this.coinbase)
@@ -260,8 +259,8 @@ class Console(BaseService):
             serpent = None
             pass
 
-        self.console_locals = dict(eth=Eth(self.app),solidity=solc_wrapper, serpent=serpent,
-                                    denoms=denoms, true=True, false=False, Eth=Eth)
+        self.console_locals = dict(eth=Eth(self.app), solidity=solc_wrapper, serpent=serpent,
+                                   denoms=denoms, true=True, false=False, Eth=Eth)
 
         for k, v in self.app.script_globals.items():
             self.console_locals[k] = v

--- a/pyethapp/console_service.py
+++ b/pyethapp/console_service.py
@@ -30,7 +30,8 @@ GUI_GEVENT = 'gevent'
 
 
 def normalize_address(a, allow_blank=True):
-    a = a or '\0' * 20 if allow_blank else a
+    if not allow_blank and a == '':
+        a = '\0' * 20
     return _normalize_address(a)
 
 

--- a/pyethapp/console_service.py
+++ b/pyethapp/console_service.py
@@ -32,7 +32,7 @@ GUI_GEVENT = 'gevent'
 def normalize_address(a, allow_blank=True):
     if not allow_blank and a == '':
         a = '\0' * 20
-    return _normalize_address(a)
+    return _normalize_address(a, allow_blank)
 
 
 def inputhook_gevent():

--- a/pyethapp/console_service.py
+++ b/pyethapp/console_service.py
@@ -19,7 +19,7 @@ import IPython.core.shellapp
 from IPython.lib.inputhook import inputhook_manager, stdin_ready
 from ethereum.slogging import getLogger
 from ethereum.transactions import Transaction
-from ethereum.utils import denoms, normalize_address as _normalize_address, bcolors as bc
+from ethereum.utils import denoms, normalize_address, bcolors as bc
 
 from rpc_client import ABIContract
 
@@ -27,12 +27,6 @@ log = getLogger(__name__)
 
 ENTER_CONSOLE_TIMEOUT = 3
 GUI_GEVENT = 'gevent'
-
-
-def normalize_address(a, allow_blank=True):
-    if not allow_blank and a == '':
-        a = '\0' * 20
-    return _normalize_address(a, allow_blank)
 
 
 def inputhook_gevent():

--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -15,19 +15,8 @@ from ethereum.utils import denoms, int_to_big_endian, big_endian_to_int, normali
 z_address = '\x00' * 20
 
 
-def address20(address):
-    if address == '':
-        return address
-    if len(address) == '42':
-        address = address[2:]
-    if len(address) == 40:
-        address = address.decode('hex')
-    assert len(address) == 20
-    return address
-
-
 def address_encoder(a):
-    return _address_encoder(normalize_address(a))
+    return _address_encoder(normalize_address(a, allow_blank=True))
 
 
 def block_tag_encoder(val):

--- a/pyethapp/tests/test_console_service.py
+++ b/pyethapp/tests/test_console_service.py
@@ -60,20 +60,6 @@ def test_app(request, tmpdir):
             assert self.services.chain.chain.head.difficulty == 1
             return self.services.chain.chain.head
 
-        def rpc_request(self, method, *args):
-            """Simulate an incoming JSON RPC request and return the result.
-
-            Example::
-
-                >>> assert test_app.rpc_request('eth_getBalance', '0x' + 'ff' * 20) == '0x0'
-
-            """
-            log.debug('simulating rpc request', method=method)
-            method = self.services.jsonrpc.dispatcher.get_method(method)
-            res = method(*args)
-            log.debug('got response', response=res)
-            return res
-
     config = {
         'data_dir': str(tmpdir),
         'db': {'implementation': 'EphemDB'},

--- a/pyethapp/tests/test_console_service.py
+++ b/pyethapp/tests/test_console_service.py
@@ -1,0 +1,146 @@
+from itertools import count
+import pytest
+import serpent
+from devp2p.peermanager import PeerManager
+import ethereum
+from ethereum import tester
+from ethereum.ethpow import mine
+import ethereum.keys
+import ethereum.config
+from ethereum.slogging import get_logger
+from pyethapp.accounts import Account, AccountsService, mk_random_privkey
+from pyethapp.app import EthApp
+from pyethapp.config import update_config_with_defaults, get_default_config
+from pyethapp.db_service import DBService
+from pyethapp.eth_service import ChainService
+from pyethapp.jsonrpc import JSONRPCServer
+from pyethapp.pow_service import PoWService
+from pyethapp.console_service import Console
+
+# reduce key derivation iterations
+ethereum.keys.PBKDF2_CONSTANTS['c'] = 100
+
+
+log = get_logger('test.console_service')
+
+
+@pytest.fixture
+def test_app(request, tmpdir):
+
+    class TestApp(EthApp):
+
+        def start(self):
+            super(TestApp, self).start()
+            log.debug('adding test accounts')
+            # high balance account
+            self.services.accounts.add_account(Account.new('', tester.keys[0]), store=False)
+            # low balance account
+            self.services.accounts.add_account(Account.new('', tester.keys[1]), store=False)
+            # locked account
+            locked_account = Account.new('', tester.keys[2])
+            locked_account.lock()
+            self.services.accounts.add_account(locked_account, store=False)
+            assert set(acct.address for acct in self.services.accounts) == set(tester.accounts[:3])
+
+        def mine_next_block(self):
+            """Mine until a valid nonce is found.
+
+            :returns: the new head
+            """
+            log.debug('mining next block')
+            block = self.services.chain.chain.head_candidate
+            delta_nonce = 10**6
+            for start_nonce in count(0, delta_nonce):
+                bin_nonce, mixhash = mine(block.number, block.difficulty, block.mining_hash,
+                                          start_nonce=start_nonce, rounds=delta_nonce)
+                if bin_nonce:
+                    break
+            self.services.pow.recv_found_nonce(bin_nonce, mixhash, block.mining_hash)
+            log.debug('block mined')
+            assert self.services.chain.chain.head.difficulty == 1
+            return self.services.chain.chain.head
+
+        def rpc_request(self, method, *args):
+            """Simulate an incoming JSON RPC request and return the result.
+
+            Example::
+
+                >>> assert test_app.rpc_request('eth_getBalance', '0x' + 'ff' * 20) == '0x0'
+
+            """
+            log.debug('simulating rpc request', method=method)
+            method = self.services.jsonrpc.dispatcher.get_method(method)
+            res = method(*args)
+            log.debug('got response', response=res)
+            return res
+
+    config = {
+        'data_dir': str(tmpdir),
+        'db': {'implementation': 'EphemDB'},
+        'pow': {'activated': False},
+        'p2p': {
+            'min_peers': 0,
+            'max_peers': 0,
+            'listen_port': 29873
+        },
+        'node': {'privkey_hex': mk_random_privkey().encode('hex')},
+        'discovery': {
+            'boostrap_nodes': [],
+            'listen_port': 29873
+        },
+        'eth': {
+            'block': {  # reduced difficulty, increased gas limit, allocations to test accounts
+                'GENESIS_DIFFICULTY': 1,
+                'BLOCK_DIFF_FACTOR': 2,  # greater than difficulty, thus difficulty is constant
+                'GENESIS_GAS_LIMIT': 3141592,
+                'GENESIS_INITIAL_ALLOC': {
+                    tester.accounts[0].encode('hex'): {'balance': 10**24},
+                    tester.accounts[1].encode('hex'): {'balance': 1},
+                    tester.accounts[2].encode('hex'): {'balance': 10**24},
+                }
+            }
+        },
+        'jsonrpc': {'listen_port': 29873}
+    }
+    services = [DBService, AccountsService, PeerManager, ChainService, PoWService, JSONRPCServer, Console]
+    update_config_with_defaults(config, get_default_config([TestApp] + services))
+    update_config_with_defaults(config, {'eth': {'block': ethereum.config.default_config}})
+    app = TestApp(config)
+    for service in services:
+        service.register_with_app(app)
+
+    def fin():
+        log.debug('stopping test app')
+        app.stop()
+    request.addfinalizer(fin)
+
+    log.debug('starting test app')
+    app.start()
+    return app
+
+
+def test_send_transaction_with_contract(test_app):
+    serpent_code = '''
+def main(a,b):
+    return(a ^ b)
+'''
+    tx_to = b''
+    evm_code = serpent.compile(serpent_code)
+    chain = test_app.services.chain.chain
+    assert chain.head_candidate.get_balance(tx_to) == 0
+    sender = test_app.services.accounts.unlocked_accounts[0].address
+    assert chain.head_candidate.get_balance(sender) > 0
+
+    eth = test_app.services.console.console_locals['eth']
+    tx = eth.transact(to='', data=evm_code, startgas=500000, sender=sender)
+
+    code = chain.head_candidate.account_to_dict(tx.creates)['code']
+    assert len(code) > 2
+    assert code != '0x'
+
+    test_app.mine_next_block()
+
+    creates = chain.head.get_transaction(0).creates
+    code = chain.head.account_to_dict(creates)['code']
+    assert len(code) > 2
+    assert code != '0x'

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -230,7 +230,7 @@ def test_send_transaction_with_contract(test_app):
 def main(a,b):
     return(a ^ b)
 '''
-    tx_to = b'';
+    tx_to = b''
     evm_code = serpent.compile(serpent_code)
     chain = test_app.services.chain.chain
     assert chain.head_candidate.get_balance(tx_to) == 0


### PR DESCRIPTION
Hi,

I'm just getting started with `pyethapp` so I was working through the console guide:
https://github.com/ethereum/pyethapp/wiki/The_Console
When I got to the Creating Contracts section, https://github.com/ethereum/pyethapp/wiki/The_Console#creating-contracts , I wasn't able to get the `NameReg` contract properly created so that I could later interact with it.  After reviewing some of the `pyethereum` code, it didn't seem to be going down the `create_contract` path here https://github.com/ethereum/pyethereum/blob/develop/ethereum/processblock.py#L165  
I was still able to run `eth.find_transaction(tx)` and see a result similar to what was in the create contract section of the console guide so I thought everything had been set up properly at first. However, when I tried to interact with it, I always got `''` back when I got to the `namereg.resolve(eth.coinbase)` part.   

The adjustments in this pull request allow me to create a contract based on the example in the console guide such that I can interact with it.   However, I'm not sure if these adjustments are the best way to address it.   It looks like there's a `normalize_address` function over in https://github.com/ethereum/pyethereum/blob/develop/ethereum/utils.py#L138 that appears to already handle the blank address for contract creation.   I would have just called it, but I wasn't sure about changing the `'\0' * 20` behavior when a blank is not allowed in the pyethapp version of `normalize_address`.  I'm happy to make further refinements and/or add more test coverage for this area if it looks like I'm heading down the right path to fix it up.

Thank you,

Brian
