### PR TITLE
Add support for the eth_sendRawTransaction JSON RPC method

### DIFF
--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -1086,6 +1086,35 @@ class Chain(Subdispatcher):
         return data_encoder(tx.hash)
 
     @public
+    @decode_arg('data', data_decoder)
+    def sendRawTransaction(self, data):
+        """
+        decode sendRawTransaction request data, format it and relay along to the sendTransaction method
+        to ensure the same validations and processing rules are applied
+        """
+        tx_data = rlp.codec.decode(data, ethereum.transactions.Transaction)
+
+        tx_dict = tx_data.to_dict()
+        # encode addresses
+        tx_dict['from'] = address_encoder(tx_dict.get('sender', ''))
+        to_value = tx_dict.get('to', '')
+        if to_value:
+            tx_dict['to'] = address_encoder(to_value)
+
+        # encode data
+        tx_dict['data'] = data_encoder(tx_dict.get('data', b''))
+
+        # encode quantities included in the raw transaction data
+        gasprice_key = 'gasPrice' if 'gasPrice' in tx_dict else 'gasprice'
+        gas_key = 'gas' if 'gas' in tx_dict else 'startgas'
+        for key in ('value', 'nonce', gas_key, gasprice_key, 'v', 'r', 's'):
+            if key in tx_dict:
+                tx_dict[key] = quantity_encoder(tx_dict[key])
+
+        # relay the information along to the sendTransaction method for processing
+        return self.sendTransaction(tx_dict)
+
+    @public
     @decode_arg('block_id', block_id_decoder)
     @encode_res(data_encoder)
     def call(self, data, block_id='pending'):

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -1,6 +1,7 @@
 from itertools import count
 import json
 import pytest
+import rlp
 import serpent
 from devp2p.peermanager import PeerManager
 import ethereum
@@ -15,7 +16,7 @@ from pyethapp.config import update_config_with_defaults, get_default_config
 from pyethapp.db_service import DBService
 from pyethapp.eth_service import ChainService
 from pyethapp.jsonrpc import JSONRPCServer, quantity_encoder, address_encoder, data_decoder,   \
-    data_encoder
+    data_encoder, default_gasprice, default_startgas
 from pyethapp.pow_service import PoWService
 
 # reduce key derivation iterations
@@ -242,6 +243,36 @@ def main(a,b):
         'data': evm_code.encode('hex')
     }
     data_decoder(test_app.rpc_request('eth_sendTransaction', tx))
+    creates = chain.head_candidate.get_transaction(0).creates
+
+    code = chain.head_candidate.account_to_dict(creates)['code']
+    assert len(code) > 2
+    assert code != '0x'
+
+    test_app.mine_next_block()
+
+    creates = chain.head.get_transaction(0).creates
+    code = chain.head.account_to_dict(creates)['code']
+    assert len(code) > 2
+    assert code != '0x'
+
+
+def test_send_raw_transaction_with_contract(test_app):
+    serpent_code = '''
+def main(a,b):
+    return(a ^ b)
+'''
+    tx_to = b''
+    evm_code = serpent.compile(serpent_code)
+    chain = test_app.services.chain.chain
+    assert chain.head_candidate.get_balance(tx_to) == 0
+    sender = test_app.services.accounts.unlocked_accounts[0].address
+    assert chain.head_candidate.get_balance(sender) > 0
+    nonce = chain.head_candidate.get_nonce(sender)
+    tx = ethereum.transactions.Transaction(nonce, default_gasprice, default_startgas, tx_to, 0, evm_code, 0, 0, 0)
+    test_app.services.accounts.sign_tx(sender, tx)
+    raw_transaction = data_encoder(rlp.codec.encode(tx, ethereum.transactions.Transaction))
+    data_decoder(test_app.rpc_request('eth_sendRawTransaction', raw_transaction))
     creates = chain.head_candidate.get_transaction(0).creates
 
     code = chain.head_candidate.account_to_dict(creates)['code']


### PR DESCRIPTION
Hi,

While reviewing some other tools and libraries, I encountered a "method not found" error when using them to submit a contract to pyethapp.   It turned out that those other tools were using the `eth_sendRawTransaction` JSON RPC method https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sendrawtransaction

These adjustments add support in pyethapp for `eth_sendRawTransaction` along with a new test case in the JSON RPC test suite to help provide code coverage for it.

Thanks,

Brian
