### PR TITLE
add console service test case for NameReg solidity contract

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
+sudo: required
+dist: trusty
 python:
 - '2.7'
+before_install:
+    - sudo add-apt-repository -y ppa:ethereum/ethereum
+    - sudo apt-get update
+    - sudo apt-get install -y solc
 install:
 - pip install -r requirements.txt
 - pip install coveralls readme_renderer

--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -205,8 +205,7 @@ class JSONRPCClient(object):
         return ABIContract(sender, _abi, address, self.eth_call, self.send_transaction)
 
 
-class ABIContract():
-
+class ABIContract(object):
     """
     proxy for a contract
     """

--- a/pyethapp/tests/test_console_service.py
+++ b/pyethapp/tests/test_console_service.py
@@ -13,7 +13,6 @@ from pyethapp.app import EthApp
 from pyethapp.config import update_config_with_defaults, get_default_config
 from pyethapp.db_service import DBService
 from pyethapp.eth_service import ChainService
-from pyethapp.jsonrpc import JSONRPCServer
 from pyethapp.pow_service import PoWService
 from pyethapp.console_service import Console
 
@@ -88,7 +87,7 @@ def test_app(request, tmpdir):
         },
         'jsonrpc': {'listen_port': 29873}
     }
-    services = [DBService, AccountsService, PeerManager, ChainService, PoWService, JSONRPCServer, Console]
+    services = [DBService, AccountsService, PeerManager, ChainService, PoWService, Console]
     update_config_with_defaults(config, get_default_config([TestApp] + services))
     update_config_with_defaults(config, {'eth': {'block': ethereum.config.default_config}})
     app = TestApp(config)


### PR DESCRIPTION
Hi,

I added a console service test case to follow along with the https://github.com/ethereum/pyethapp/wiki/The_Console#creating-contracts section that I'd referenced in https://github.com/ethereum/pyethapp/pull/123   This may help out with some of the new issues like https://github.com/ethereum/pyethapp/issues/127   

The wiki uses `tx = namereg.register('alice')` but when I run that with the current develop branch, 
it ends up being reverted (may be like #127 is describing?)   I found that if I adjusted that to 
`namereg.register('alice', startgas=90000, gasprice=50 * 10**9)` it would run OK and `namereg.resolve(eth.coinbase)` would return the proper value.   

I'm not sure if different defaults are needed here https://github.com/ethereum/pyethapp/blob/develop/pyethapp/console_service.py#L194 or if the https://github.com/ethereum/pyethapp/wiki/The_Console wiki needs to be edited to include the startgas and gasprice parameters.

I'd like to help continue building up console service test cases also as I'm using it quite a bit now.   Let me know if I can extend anything with this to help out with #126 and #127 

Thanks,

Brian
