### PR TITLE
Fix rpc nonce vs transaction count

### DIFF
--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -603,7 +603,7 @@ class Personal(Subdispatcher):
 
     """Subdispatcher for account-related RPC methods.
 
-    NOTE: this do not seem to be part of the official JSON-RPC specs but instead part of
+    NOTE: this does not seem to be part of the official JSON-RPC specs but instead part of
     go-ethereum's JavaScript-Console: https://github.com/ethereum/go-ethereum/wiki/JavaScript-Console#personal
 
     It is needed for MIST-IPC.
@@ -1044,13 +1044,14 @@ class Chain(Subdispatcher):
 
     @public
     @decode_arg('address', address_decoder)
+    @decode_arg('block_id', block_id_decoder)
     @encode_res(quantity_encoder)
     def nonce(self, address, block_id='pending'):
         """
         Return the `nonce` for `address` at the current `block_id
         :param address:
         :param block_id:
-        :return: the newest nonce for the address/account
+        :return: the next nonce for the address/account
         """
         assert address is not None
         block = self.json_rpc_server.get_block(block_id)

--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -1043,6 +1043,23 @@ class Chain(Subdispatcher):
         return self.app.services.accounts.coinbase
 
     @public
+    @decode_arg('address', address_decoder)
+    @encode_res(quantity_encoder)
+    def nonce(self, address, block_id='pending'):
+        """
+        Return the `nonce` for `address` at the current `block_id
+        :param address:
+        :param block_id:
+        :return: the newest nonce for the address/account
+        """
+        assert address is not None
+        block = self.json_rpc_server.get_block(block_id)
+        assert block is not None
+        nonce = block.get_nonce(address)
+        assert nonce is not None and isinstance(nonce, int)
+        return nonce
+
+    @public
     def sendTransaction(self, data):
         """
         extend spec to support v,r,s signed transactions

--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -428,23 +428,27 @@ class JSONRPCClient(object):
         if to == '0' * 40:
             warnings.warn('For contract creating the empty string must be used.')
 
-        if not sender and not (v and r and s):
-            raise ValueError('Either sender or v, r, s needs to be informed.')
-
         json_data = {
-            'from': address_encoder(sender),
             'to': data_encoder(normalize_address(to, allow_blank=True)),
-            'nonce': quantity_encoder(nonce),
             'value': quantity_encoder(value),
             'gasPrice': quantity_encoder(gasPrice),
             'gas': quantity_encoder(gas),
             'data': data_encoder(data),
         }
 
+        if not sender and not (v and r and s):
+            raise ValueError('Either sender or v, r, s needs to be informed.')
+
+        if sender is not None:
+            json_data['from'] = address_encoder(sender)
+
         if v and r and s:
             json_data['v'] = quantity_encoder(v)
             json_data['r'] = quantity_encoder(r)
             json_data['s'] = quantity_encoder(s)
+
+        if nonce is not None:
+            json_data['nonce'] = quantity_encoder(nonce)
 
         res = self.call('eth_sendTransaction', json_data)
 

--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -150,7 +150,7 @@ class JSONRPCClient(object):
         if len(address) == 40:
             address = address.decode('hex')
 
-        res = self.call('eth_getTransactionCount', address_encoder(address), 'pending')
+        res = self.call('eth_nonce', address_encoder(address), 'pending')
         return quantity_decoder(res)
 
     def balance(self, account):

--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -150,8 +150,16 @@ class JSONRPCClient(object):
         if len(address) == 40:
             address = address.decode('hex')
 
-        res = self.call('eth_nonce', address_encoder(address), 'pending')
-        return quantity_decoder(res)
+        try:
+            res = self.call('eth_nonce', address_encoder(address), 'pending')
+            return quantity_decoder(res)
+        except JSONRPCClientReplyError as e:
+            if e.message == 'Method not found':
+                raise JSONRPCClientReplyError(
+                    "'eth_nonce' is not supported by your endpoint (pyethapp only). "
+                    "For transactions use server-side nonces: "
+                    "('eth_sendTransaction' with 'nonce=None')")
+            raise e
 
     def balance(self, account):
         """ Return the balance of the account of given address. """

--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -9,7 +9,7 @@ from ethereum.abi import ContractTranslator
 from ethereum.keys import privtoaddr
 from ethereum.transactions import Transaction
 from ethereum.utils import denoms, int_to_big_endian, big_endian_to_int, normalize_address
-from ethereum._solidity import compile_file, solidity_unresolved_symbols, solidity_library_symbol, solidity_resolve_symbols
+from ethereum._solidity import solidity_unresolved_symbols, solidity_library_symbol, solidity_resolve_symbols
 from tinyrpc.protocols.jsonrpc import JSONRPCErrorResponse, JSONRPCSuccessResponse
 from tinyrpc.protocols.jsonrpc import JSONRPCProtocol
 from tinyrpc.transports.http import HttpPostClientTransport

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -2,6 +2,7 @@
 import os
 from os import path
 from itertools import count
+import gevent
 
 import pytest
 import rlp
@@ -208,7 +209,12 @@ def test_app(request, tmpdir):
     def fin():
         log.debug('stopping test app')
         for service in app.services:
-            app.services[service].stop()
+            gevent.sleep(.1)
+            try:
+                app.services[service].stop()
+            except Exception as e:
+                log.DEV(str(e), exc_info=e)
+                pass
         app.stop()
     request.addfinalizer(fin)
 

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+import os
 from os import path
 from itertools import count
 import gevent

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -1,5 +1,4 @@
 # -*- coding: utf8 -*-
-import os
 from os import path
 from itertools import count
 import gevent
@@ -25,7 +24,6 @@ from pyethapp.jsonrpc import Compilers, JSONRPCServer, quantity_encoder, address
     data_encoder, default_gasprice, default_startgas
 from pyethapp.profiles import PROFILES
 from pyethapp.pow_service import PoWService
-from pyethapp.jsonrpc import Compilers
 
 ethereum.keys.PBKDF2_CONSTANTS['c'] = 100  # faster key derivation
 log = get_logger('test.jsonrpc')  # pylint: disable=invalid-name
@@ -97,8 +95,8 @@ def test_compile_solidity():
     }
     compiler_result = Compilers().compileSolidity(solidity_code)
 
-    assert set(compiler_result.keys()) == {'test',}
-    assert set(compiler_result['test'].keys()) == {'info', 'code',}
+    assert set(compiler_result.keys()) == {'test', }
+    assert set(compiler_result['test'].keys()) == {'info', 'code', }
     assert set(compiler_result['test']['info']) == {
         'abiDefinition',
         'compilerVersion',
@@ -145,7 +143,7 @@ def test_app(request, tmpdir):
             """
             log.debug('mining next block')
             block = self.services.chain.chain.head_candidate
-            delta_nonce = 10**6
+            delta_nonce = 10 ** 6
             for start_nonce in count(0, delta_nonce):
                 bin_nonce, mixhash = mine(block.number, block.difficulty, block.mining_hash,
                                           start_nonce=start_nonce, rounds=delta_nonce)
@@ -191,9 +189,9 @@ def test_app(request, tmpdir):
                 'BLOCK_DIFF_FACTOR': 2,  # greater than difficulty, thus difficulty is constant
                 'GENESIS_GAS_LIMIT': 3141592,
                 'GENESIS_INITIAL_ALLOC': {
-                    tester.accounts[0].encode('hex'): {'balance': 10**24},
+                    tester.accounts[0].encode('hex'): {'balance': 10 ** 24},
                     tester.accounts[1].encode('hex'): {'balance': 1},
-                    tester.accounts[2].encode('hex'): {'balance': 10**24},
+                    tester.accounts[2].encode('hex'): {'balance': 10 ** 24},
                 }
             }
         },
@@ -446,6 +444,7 @@ def test_get_logs(test_app):
 def test_get_filter_changes(test_app):
     test_app.mine_next_block()  # start with a fresh block
     n0 = test_app.services.chain.chain.head.number
+    assert n0 == 1
     sender = address_encoder(test_app.services.accounts.unlocked_accounts[0].address)
     contract_creation = {
         'from': sender,

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -2,6 +2,7 @@
 from os import path
 from itertools import count
 import gevent
+import gc
 
 import pytest
 import rlp
@@ -214,6 +215,8 @@ def test_app(request, tmpdir):
                 log.DEV(str(e), exc_info=e)
                 pass
         app.stop()
+        gevent.killall(task for task in gc.get_objects() if isinstance(task, gevent.Greenlet))
+
     request.addfinalizer(fin)
 
     log.debug('starting test app')

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -22,6 +22,7 @@ from pyethapp.db_service import DBService
 from pyethapp.eth_service import ChainService
 from pyethapp.jsonrpc import Compilers, JSONRPCServer, quantity_encoder, address_encoder, data_decoder,   \
     data_encoder, default_gasprice, default_startgas
+from pyethapp.profiles import PROFILES
 from pyethapp.pow_service import PoWService
 from pyethapp.jsonrpc import Compilers
 
@@ -117,7 +118,8 @@ def test_compile_solidity():
     assert compiler_info['abiDefinition'] == info['abiDefinition']
 
 
-@pytest.fixture
+@pytest.fixture(params=[0,
+    PROFILES['testnet']['eth']['block']['ACCOUNT_INITIAL_NONCE']])
 def test_app(request, tmpdir):
 
     class TestApp(EthApp):
@@ -183,6 +185,7 @@ def test_app(request, tmpdir):
         },
         'eth': {
             'block': {  # reduced difficulty, increased gas limit, allocations to test accounts
+                'ACCOUNT_INITIAL_NONCE': request.param,
                 'GENESIS_DIFFICULTY': 1,
                 'BLOCK_DIFF_FACTOR': 2,  # greater than difficulty, thus difficulty is constant
                 'GENESIS_GAS_LIMIT': 3141592,
@@ -193,7 +196,7 @@ def test_app(request, tmpdir):
                 }
             }
         },
-        'jsonrpc': {'listen_port': 29873}
+        'jsonrpc': {'listen_port': 4488, 'listen_host': '127.0.0.1'}
     }
     services = [DBService, AccountsService, PeerManager, ChainService, PoWService, JSONRPCServer]
     update_config_with_defaults(config, get_default_config([TestApp] + services))


### PR DESCRIPTION
Since
1) the testnet/`morden` doesn't use account nonces starting from 0, 
2) `pyethapp/rpc_client.py::eth_sendTransaction` wants to allow for client side signed transactions
we need to have a stable way to figure out nonces in `rpc_client`.

This PR adds a new (non-spec!) jsonrpc-method `eth_nonce` that is used in `rpc_client`. It also adds a test and expands `test_jsonrpc.py` to be also run against testnet like `initial account nonce` settings.
