### PR TITLE
Rpc client fixes

### DIFF
--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -194,7 +194,7 @@ class JSONRPCClient(object):
         )
 
     def deploy_solidity_contract(self, sender, contract_name, all_contracts,  # pylint: disable=too-many-locals
-                                 libraries, contructor_paramenters, timeout=None):
+                                 libraries, constructor_parameters, timeout=None, gasprice=denoms.wei):
 
         if contract_name not in all_contracts:
             raise ValueError('Unkonwn contract {}'.format(contract_name))
@@ -235,7 +235,7 @@ class JSONRPCClient(object):
                     sender,
                     to='',
                     data=bytecode,
-                    gasprice=denoms.wei,
+                    gasprice=gasprice,
                 )
 
                 self.poll(transaction_hash.decode('hex'), timeout=timeout)
@@ -250,9 +250,9 @@ class JSONRPCClient(object):
             contract['bin_hex'] = hex_bytecode
             contract['bin'] = bytecode
 
-        if contructor_paramenters:
+        if constructor_parameters:
             translator = ContractTranslator(contract_interface)
-            parameters = translator.encode_constructor_arguments(contructor_paramenters)
+            parameters = translator.encode_constructor_arguments(constructor_parameters)
             bytecode = contract['bin'] + parameters
         else:
             bytecode = contract['bin']
@@ -261,7 +261,7 @@ class JSONRPCClient(object):
             sender,
             to='',
             data=bytecode,
-            gasprice=denoms.wei,
+            gasprice=gasprice,
         )
 
         self.poll(transaction_hash.decode('hex'), timeout=timeout)

--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -532,6 +532,12 @@ class JSONRPCClient(object):
         transaction_hash = data_encoder(transaction_hash)
 
         pending_block = self.call('eth_getBlockByNumber', 'pending', True)
+
+        # give the server some time to add the tx to pending
+        if not any(tx['hash'] == transaction_hash for tx in pending_block['transactions']):
+            if timeout:
+                gevent.sleep(timeout / 2000.)
+
         while any(tx['hash'] == transaction_hash for tx in pending_block['transactions']):
             if deadline and time.time() > deadline:
                 raise Exception('timeout')


### PR DESCRIPTION
This fixes a few issues with contract deployments:
- `gasprice` was fixed at `1 wei`
- `poll`-ing can fail, if the remote doesn't add the tx to the `pending` block right away. This is now a little more lenient.
