### PR TITLE
Add ssl option for rpc endpoint

### DIFF
--- a/pyethapp/rpc_client.py
+++ b/pyethapp/rpc_client.py
@@ -116,9 +116,11 @@ class JSONRPCClientReplyError(Exception):
 class JSONRPCClient(object):
     protocol = JSONRPCProtocol()
 
-    def __init__(self, host='127.0.0.1', port=4000, print_communication=True, privkey=None, sender=None):
+    def __init__(self, host='127.0.0.1', port=4000, print_communication=True,
+                 privkey=None, sender=None, use_ssl=False):
         "specify privkey for local signing"
-        self.transport = HttpPostClientTransport('http://{}:{}'.format(host, port))
+        self.transport = HttpPostClientTransport('{}://{}:{}'.format(
+            'https' if use_ssl else 'http', host, port))
         self.print_communication = print_communication
         self.privkey = privkey
         self._sender = sender


### PR DESCRIPTION
Implements #163. This adds support for `https` URLs. Tried to do it with minimal changes to avoid impacting existing clients.
