### PR TITLE
test_logfilters_topics: skip if solc not available

### DIFF
--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -318,6 +318,7 @@ contract SampleContract {
 """
 
 
+@pytest.mark.skipif(not SOLIDITY_AVAILABLE, reason='solidity compiler not available')
 def test_logfilters_topics(test_app):
     # slogging.configure(':trace')
     sample_compiled = _solidity.compile_code(


### PR DESCRIPTION
That test requires solc, so must be skipped when it's not available.