### PR TITLE
rpc: tx_encoder now includes r,s,v values

### DIFF
--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -499,6 +499,9 @@ def tx_encoder(transaction, block, i, pending):
         'gasPrice': quantity_encoder(transaction.gasprice),
         'gas': quantity_encoder(transaction.startgas),
         'input': data_encoder(transaction.data),
+        'r': quantity_encoder(transaction.r),
+        's': quantity_encoder(transaction.s),
+        'v': quantity_encoder(transaction.v),
     }
 
 


### PR DESCRIPTION
This makes the JSON schema of Transactions compatible with the other clients.

Part of #190 