### PR TITLE
Fix breaking change in pyelliptic 1.5.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ ethereum>=1.5.1
 pbkdf2
 scrypt
 pexpect
+pyelliptic==1.5.7


### PR DESCRIPTION
Fixes breaking change in pyelliptic 1.5.8 that causes app install to fail.

```
ubuntu@ip-172-31-20-133:~/pyethapp$ pyethapp
Traceback (most recent call last):
  File "/usr/local/bin/pyethapp", line 11, in <module>
    load_entry_point('pyethapp', 'console_scripts', 'pyethapp')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 560, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2648, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2302, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2308, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/ubuntu/pyethapp/pyethapp/app.py", line 15, in <module>
    from devp2p.app import BaseApp
  File "/usr/local/lib/python2.7/dist-packages/devp2p/app.py", line 8, in <module>
    from devp2p import crypto
  File "/usr/local/lib/python2.7/dist-packages/devp2p/crypto.py", line 7, in <module>
    import pyelliptic
  File "/usr/local/lib/python2.7/dist-packages/pyelliptic/__init__.py", line 43, in <module>
    from .openssl import OpenSSL
  File "/usr/local/lib/python2.7/dist-packages/pyelliptic/openssl.py", line 310, in <module>
    OpenSSL = _OpenSSL(libname)
  File "/usr/local/lib/python2.7/dist-packages/pyelliptic/openssl.py", line 144, in __init__
    self.EVP_CIPHER_CTX_reset = self._lib.EVP_CIPHER_CTX_reset
  File "/usr/lib/python2.7/ctypes/__init__.py", line 378, in __getattr__
    func = self.__getitem__(name)
  File "/usr/lib/python2.7/ctypes/__init__.py", line 383, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: /lib/x86_64-linux-gnu/libcrypto.so.1.0.0: undefined symbol: EVP_CIPHER_CTX_reset
```