### PR TITLE
Fix TransientBlock.hex_hash

### DIFF
--- a/pyethapp/eth_protocol.py
+++ b/pyethapp/eth_protocol.py
@@ -45,7 +45,7 @@ class TransientBlock(rlp.Serializable):
 
     @property
     def hex_hash(self):
-        return self.header.hex_hash()
+        return self.header.hex_hash
 
     def __repr__(self):
         return '<TransientBlock(#%d %s)>' % (self.header.number, self.header.hash.encode('hex')[:8])


### PR DESCRIPTION
It was calling BlockHeader.hex_hash as if it was a method but that's
actually a @property now