### PR TITLE
Fix PoWService

### DIFF
--- a/pyethapp/tests/test_pow_service.py
+++ b/pyethapp/tests/test_pow_service.py
@@ -5,8 +5,8 @@ from devp2p.app import BaseApp
 from devp2p.service import BaseService
 from ethereum import slogging
 from ethereum.block import Block, BlockHeader
-from ethereum.config import Env
 from ethereum.db import DB
+from ethereum.transaction_queue import TransactionQueue
 
 from pyethapp.pow_service import PoWService
 
@@ -17,17 +17,11 @@ TIMEOUT = 15       # Timeout for single block being minded.
 class ChainServiceMock(BaseService):
     name = 'chain'
 
-    class ChainMock:
-        def __init__(self):
-            env = Env(DB())
-            header = BlockHeader(difficulty=DIFFICULTY)
-            self.head_candidate = Block(header, env=env)
-
     def __init__(self, app):
         super(ChainServiceMock, self).__init__(app)
-        self.on_new_head_candidate_cbs = []
+        self.on_new_head_cbs = []
+        self.transaction_queue = TransactionQueue()
         self.is_syncing = False
-        self.chain = self.ChainMock()
         self.mined_block = None
         self.block_mined_event = Event()
 
@@ -35,12 +29,15 @@ class ChainServiceMock(BaseService):
         assert self.mined_block is None
         self.mined_block = block
         self.block_mined_event.set()
+        return True
 
 
 @pytest.fixture
 def app(request):
     app = BaseApp()
     ChainServiceMock.register_with_app(app)
+    PoWService.make_head_candidate = lambda self: Block(
+        BlockHeader(difficulty=DIFFICULTY), db=DB())
     PoWService.register_with_app(app)
     app.start()
     request.addfinalizer(lambda: app.stop())
@@ -53,7 +50,7 @@ def test_pow_default(app):
 
     assert pow
     assert chain
-    assert len(chain.on_new_head_candidate_cbs) == 1
+    assert len(chain.on_new_head_cbs) == 1
     assert not pow.active
     assert not app.config['pow']['activated']
     assert app.config['pow']['cpu_pct'] == 100


### PR DESCRIPTION
I fixed it by keeping track of the head candidate in PoWService itself, and the candidate gets updated either when there's a new chain head or when the local miner subprocess successfully mines a block. 

It occurred to me that it might make more sense to keep track of the head candidate in ChainService instead, as the jsonrpc service needs it too, but since it was originally there and has been removed as part of the recent state_revamp work, I thought I'd ask for feedback here before spending more time on this. So, does this approach make sense at all or did you guys have something else in mind?