### PR TITLE
Fixes solidity warnings

### DIFF
--- a/pyethapp/console_service.py
+++ b/pyethapp/console_service.py
@@ -259,7 +259,7 @@ class Console(BaseService):
                 return TransientBlock.init_from_rlp(l).to_block()
 
         try:
-            from ethereum._solidity import solc_wrapper
+            from ethereum.tools._solidity import solc_wrapper
         except ImportError:
             solc_wrapper = None
             pass

--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -711,8 +711,8 @@ class Compilers(Subdispatcher):
             except ImportError:
                 pass
             try:
-                import ethereum._solidity
-                s = ethereum._solidity.get_solidity()
+                import ethereum.tools._solidity
+                s = ethereum.tools._solidity.get_solidity()
                 if s:
                     self.compilers_['solidity'] = s.compile_rich
                 else:

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -77,10 +77,18 @@ def test_compile_solidity():
     with open(path.join(path.dirname(__file__), 'contracts', 'multiply.sol')) as handler:
         solidity_code = handler.read()
 
-    solidity = ethereum._solidity.get_solidity()  # pylint: disable=protected-access
-
-    abi = solidity.mk_full_signature(solidity_code)
-    code = data_encoder(solidity.compile(solidity_code))
+    filepath = None
+    contract_name = 'test'
+    compiled = _solidity.compile_code(
+        solidity_code,
+        combined='bin,abi')
+    # well it seems we could also access it directly using:
+    # compiled['test']['abi']
+    abi = _solidity.solidity_get_contract_data(compiled, filepath, contract_name)['abi']
+    # compiled['test']['bin_hex']
+    code = _solidity.solidity_get_contract_data(compiled, filepath, contract_name)['bin_hex']
+    # add the "0x" prefix to keep consistency with compileSolidity()
+    code = "0x" + code
 
     info = {
         'abiDefinition': abi,


### PR DESCRIPTION
Two tests updated:

  - test_console_name_reg_contract()
  - test_compile_solidity()

The warning was: "solc_wrapper is deprecated, ..."