### PR TITLE
Add the packaging metadata to build the pyethapp snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: pyethapp
+version: master
+summary: python based client implementing the Ethereum cryptoeconomic state machine
+description: |
+  Ethereum as a platform is focussed on enabling people to build new ideas
+  using blockchain technology.
+
+  The python implementation aims to provide an easily hackable and extendable
+  codebase.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  pyethapp:
+    command: pyethapp
+    plugs: [network, network-bind]
+
+parts:
+  pyethapp:
+    source: .
+    plugin: python
+    python-version: python2
+    build-packages: [libssl-dev]


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.