### PR TITLE
Fix rlp and tinyrpc dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,11 @@ werkzeug
 ipython>=5.4.0,<6.0.0
 statistics
 requests
-rlp>=0.4.4
+rlp>=0.5.1,<0.6.0
 devp2p>=0.8.0
 ethereum>=1.5.1
 pbkdf2
 scrypt
 pexpect
 pyelliptic==1.5.7
+tinyrpc[gevent,httpclient,jsonext,websocket,wsgi]


### PR DESCRIPTION
* fix #253: adapting the rlp version to latest devp2p
* fix #254: specifying extras

https://github.com/ethereum/pydevp2p/blob/v0.9.2/requirements.txt
https://github.com/mbr/tinyrpc