### PR TITLE
fix for tinyrpc dep dispatch three args

### DIFF
--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -100,7 +100,7 @@ class LoggingDispatcher(RPCDispatcher):
         super(LoggingDispatcher, self).__init__()
         self.logger = log.debug
 
-    def dispatch(self, request):
+    def dispatch(self, request, caller=None):
         try:
             if isinstance(request, Iterable):
                 request_list = request


### PR DESCRIPTION
Fix for the following error running the pyeth [hive client](https://github.com/karalabe/hive/tree/master/clients/pyethereum:develop):

```
[9c3a9f8c] INFO:jsonrpc starting JSONRPCServer port=8545
[9c3a9f8c] INFO:p2p.peermgr     waiting for bootstrap 
DBUG[09-25|17:14:38] client container online                  client=pyethereum:develop simulator=ethereum/consensus req-id=4966 id=9c3a9f8c time=19.354373188s
DBUG[09-25|17:14:38] new simulator request                    client=pyethereum:develop simulator=ethereum/consensus req-id=4967 from=172.17.0.3:42584 method=GET endpoint=
/nodes/9c3a9f8c
[9c3a9f8c] 
[9c3a9f8c] TypeErrorTraceback (most recent call last)
[9c3a9f8c] /usr/lib/python2.7/site-packages/gevent-1.1.0-py2.7-linux-x86_64.egg/gevent/greenlet.pyc in run(self=<Greenlet at 0x7f56bef5c690: handle_message(<Que...params":
 [], "jsonrpc": "2.0", "method": "web3_)>)
[9c3a9f8c]     532 
[9c3a9f8c]     533             try:
[9c3a9f8c] --> 534                 result = self._run(*self.args, **self.kwargs)
[9c3a9f8c]         result = undefined
[9c3a9f8c]         self._run = <function handle_message at 0x7f56bef9b398>
[9c3a9f8c]         self.args = (<Queue at 0x7f56bef8fd50 getters[1]>, '{"params": [], "jsonrpc": "2.0", "method": "web3_clientVersion", "id": 1}')
[9c3a9f8c]         self.kwargs = {}
[9c3a9f8c]     535             except:
[9c3a9f8c]     536                 self._report_error(sys.exc_info())
[9c3a9f8c] 
[9c3a9f8c] /usr/lib/python2.7/site-packages/tinyrpc-0.6-py2.7.egg/tinyrpc/server/__init__.pyc in handle_message(context=<Queue at 0x7f56bef8fd50 getters[1]>, message='{"params": [], "jsonrpc": "2.0", "method": "web3_clientVersion", "id": 1}')
[9c3a9f8c]      81                 response = self.dispatcher.dispatch(
[9c3a9f8c]      82                     request,
[9c3a9f8c] ---> 83                     getattr(self.protocol, '_caller', None)
[9c3a9f8c]      84                 )
[9c3a9f8c]      85 
[9c3a9f8c] 
[9c3a9f8c] TypeError: dispatch() takes exactly 2 arguments (3 given)
[9c3a9f8c] > /build/bdist.linux-x86_64/egg/tinyrpc/server/__init__.py(83)handle_message()
[9c3a9f8c] 
[9c3a9f8c] ipdb> 
[9c3a9f8c] Debugger exited. Do you want to quit pyethapp? [Y/n] 
[9c3a9f8c] EOFErrorTraceback (most recent call last)
[9c3a9f8c] /usr/lib/python2.7/site-packages/gevent-1.1.0-py2.7-linux-x86_64.egg/gevent/greenlet.pyc in run(self=<Greenlet at 0x7f56bef5c690: handle_message(<Que...params": [], "jsonrpc": "2.0", "method": "web3_)>)
[9c3a9f8c]     534                 result = self._run(*self.args, **self.kwargs)
[9c3a9f8c]     535             except:
[9c3a9f8c] --> 536                 self._report_error(sys.exc_info())
[9c3a9f8c]         self._report_error = <bound method Greenlet._report_error of <Greenlet at 0x7f56bef5c690: handle_message(<Queue at 0x7f56bef8fd50 getters[1]>, '{"params": [], "jsonrpc": "2.0", "method": "web3_)>>
[9c3a9f8c]         global sys.exc_info = <built-in function exc_info>
[9c3a9f8c]     537                 return
[9c3a9f8c]     538             self._report_result(result)
[9c3a9f8c] 
[9c3a9f8c] /usr/lib/python2.7/site-packages/gevent-1.1.0-py2.7-linux-x86_64.egg/gevent/greenlet.pyc in _report_error(***failed resolving arguments***)
[9c3a9f8c]     522 
[9c3a9f8c]     523         try:
[9c3a9f8c] --> 524             self.parent.handle_error(self, *exc_info)
[9c3a9f8c]         self.parent.handle_error = <bound method Hub.handle_error of <Hub at 0x7f56bf441af0 epoll default pending=0 ref=5 fileno=3 resolver=<gevent.resolver_thread.Resolver at 0x7f56bef6b0d0 pool=<ThreadPool at 0x7f56bef73290 0/1/10>> threadpool=<ThreadPool at 0x7f56bef73290 0/1/10>>>
[9c3a9f8c]         self = <Greenlet at 0x7f56bef5c690: handle_message(<Queue at 0x7f56bef8fd50 getters[1]>, '{"params": [], "jsonrpc": "2.0", "method": "web3_)>
[9c3a9f8c]         exc_info = undefined
```