### PR TITLE
Update docs.  add dependency for ubuntu/deb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Python packages:
 
 .. code:: shell
 
-    $ apt-get install build-essential automake pkg-config libtool libffi-dev libgmp-dev
+    $ apt-get install build-essential automake pkg-config libtool libffi-dev libgmp-dev libssl-dev
 
 Installation of Pyethapp and it's dependent Python packages via
 `PyPI <https://pypi.python.org/pypi/pyethapp>`__:


### PR DESCRIPTION
May seem obvious but I also needed to install libssl-dev to get the package to install via pip