### PR TITLE
Accept peers without DAO header and get rid of serpent

### DIFF
--- a/pyethapp/console_service.py
+++ b/pyethapp/console_service.py
@@ -240,13 +240,7 @@ class Console(BaseService):
             solc_wrapper = None
             pass
 
-        try:
-            import serpent
-        except ImportError:
-            serpent = None
-            pass
-
-        self.console_locals = dict(eth=Eth(self.app), solidity=solc_wrapper, serpent=serpent,
+        self.console_locals = dict(eth=Eth(self.app), solidity=solc_wrapper,
                                    denoms=denoms, true=True, false=False, Eth=Eth)
 
         for k, v in list(self.app.script_globals.items()):

--- a/pyethapp/eth_service.py
+++ b/pyethapp/eth_service.py
@@ -86,9 +86,11 @@ class DAOChallenger(object):
         try:
             dao_headers = self.deferred.get(block=True, timeout=self.request_timeout)
             log.debug("received DAO challenge answer", proto=self.proto, answer=dao_headers)
-            result = len(dao_headers) == 1 and \
+            # Accept peers without DAO header
+            result = len(dao_headers) == 0 or (
                     dao_headers[0].hash == self.config['DAO_FORK_BLKHASH'] and \
                     dao_headers[0].extra_data == self.config['DAO_FORK_BLKEXTRA']
+            )
             self.chainservice.on_dao_challenge_answer(self.proto, result)
         except gevent.Timeout:
             log.debug('challenge dao timed out', proto=self.proto)

--- a/pyethapp/jsonrpc.py
+++ b/pyethapp/jsonrpc.py
@@ -717,12 +717,6 @@ class Compilers(Subdispatcher):
         if self.compilers_ is None:
             self.compilers_ = {}
             try:
-                import serpent
-                self.compilers_['serpent'] = serpent.compile
-                self.compilers_['lll'] = serpent.compile_lll
-            except ImportError:
-                pass
-            try:
                 import ethereum.tools._solidity
                 s = ethereum.tools._solidity.get_solidity()
                 if s:
@@ -741,22 +735,6 @@ class Compilers(Subdispatcher):
     def compileSolidity(self, code):
         try:
             return self.compilers['solidity'](code)
-        except KeyError:
-            raise MethodNotFoundError()
-
-    @public
-    @encode_res(data_encoder)
-    def compileSerpent(self, code):
-        try:
-            return self.compilers['serpent'](code)
-        except KeyError:
-            raise MethodNotFoundError()
-
-    @public
-    @encode_res(data_encoder)
-    def compileLLL(self, code):
-        try:
-            return self.compilers['lll'](code)
         except KeyError:
             raise MethodNotFoundError()
 

--- a/pyethapp/tests/test_console_service.py
+++ b/pyethapp/tests/test_console_service.py
@@ -1,7 +1,6 @@
 from builtins import str
 from itertools import count
 import pytest
-import serpent
 from devp2p.peermanager import PeerManager
 import ethereum
 from ethereum.tools import tester
@@ -121,12 +120,11 @@ def test_app(request, tmpdir):
 
 
 def test_send_transaction_with_contract(test_app):
-    serpent_code = '''
-def main(a,b):
-    return(a ^ b)
-'''
     tx_to = b''
-    evm_code = serpent.compile(serpent_code)
+    # Serpent code:
+    # def main(a,b):
+    #     return(a ^ b)
+    evm_code = b'a\x00K\x80a\x00\x0e`\x009a\x00YV|\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00`\x005\x04c\x97\xd8W\xaa\x81\x14\x15a\x00IW`\x045`@R`$5``R``Q`@Q\n`\x80R` `\x80\xf3[P[`\x00\xf3'
     chain = test_app.services.chain.chain
     chainservice = test_app.services.chain
     hc_state = State(chainservice.head_candidate.state_root, chain.env)

--- a/pyethapp/tests/test_jsonrpc.py
+++ b/pyethapp/tests/test_jsonrpc.py
@@ -12,7 +12,6 @@ import gc
 
 import pytest
 import rlp
-import serpent
 import ethereum
 import ethereum.config
 import ethereum.tools.keys
@@ -580,12 +579,11 @@ def test_send_transaction(test_app):
 
 
 def test_send_transaction_with_contract(test_app):
-    serpent_code = '''
-def main(a,b):
-    return(a ^ b)
-'''
     tx_to = b''
-    evm_code = serpent.compile(serpent_code)
+    # Serpent code:
+    # def main(a,b):
+    #     return(a ^ b)
+    evm_code = b'a\x00K\x80a\x00\x0e`\x009a\x00YV|\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00`\x005\x04c\x97\xd8W\xaa\x81\x14\x15a\x00IW`\x045`@R`$5``R``Q`@Q\n`\x80R` `\x80\xf3[P[`\x00\xf3'
     chainservice = test_app.services.chain
     chain = test_app.services.chain.chain
     state = State(chainservice.head_candidate.state_root, chain.env)
@@ -616,12 +614,11 @@ def main(a,b):
 
 
 def test_send_raw_transaction_with_contract(test_app):
-    serpent_code = '''
-def main(a,b):
-    return(a ^ b)
-'''
     tx_to = b''
-    evm_code = serpent.compile(serpent_code)
+    # Serpent code:
+    # def main(a,b):
+    #     return(a ^ b)
+    evm_code = b'a\x00K\x80a\x00\x0e`\x009a\x00YV|\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00`\x005\x04c\x97\xd8W\xaa\x81\x14\x15a\x00IW`\x045`@R`$5``R``Q`@Q\n`\x80R` `\x80\xf3[P[`\x00\xf3'
     chainservice = test_app.services.chain
     chain = test_app.services.chain.chain
     state = State(chainservice.head_candidate.state_root, chain.env)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ pyelliptic==1.5.7
 tinyrpc[gevent,httpclient,jsonext,websocket,wsgi]
 pycryptodome==3.4.6
 future
-https://github.com/ethereum/serpent/tarball/develop

--- a/setup.py
+++ b/setup.py
@@ -30,18 +30,6 @@ with codecs.open('HISTORY.rst', encoding='utf8') as history_file:
 
 LONG_DESCRIPTION = README + '\n\n' + HISTORY
 
-# requirements
-install_requires = set(x.strip() for x in open('requirements.txt'))
-install_requires_replacements = {
-    'https://github.com/ethereum/serpent/tarball/develop': 'ethereum-serpent',
-}
-install_requires = [install_requires_replacements.get(r, r) for r in install_requires]
-
-# dependency links
-dependency_links = [
-    'https://github.com/ethereum/serpent/tarball/develop#egg=ethereum-serpent-9.99.9',
-]
-
 # *IMPORTANT*: Don't manually change the version here. Use the 'bump2version' utility.
 # see: https://github.com/ethereum/pyethapp/wiki/Development:-Versions-and-Releases
 version = '1.5.1a0'
@@ -73,10 +61,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     cmdclass={'test': PyTest},
-    install_requires=install_requires,
-    dependency_links=dependency_links,
     tests_require=[
-        # 'ethereum-serpent>=1.8.1',
         'mock==2.0.0',
         'pytest-mock==1.6.0',
     ],


### PR DESCRIPTION
* Thanks to @karalabe for finding this issue and giving advice.

* If the peer returns empty header list as the dao answer, it may be because the peer is not in Mainnet or the peer hasn't finished syncing yet. This patch fixed it so that we can connect to geth node in private network.

* The other commits are for passing CI (a bug of serpent). IMO it is messy now and it would be better to fix serpent or remove the serpent code in future PRs.
