### PR TITLE
Use str() instead of to_string(), as to_string() sometimes returns bytes

### DIFF
--- a/pyethapp/app.py
+++ b/pyethapp/app.py
@@ -583,7 +583,7 @@ def list_accounts(ctx):
                                                                  id='Id (if any)',
                                                                  locked='Locked'))
         for i, account in enumerate(accounts):
-            click.echo(fmt.format(i='#' + to_string(i + 1),
+            click.echo(fmt.format(i='#' + str(i + 1),
                                   address=encode_hex(account.address or ''),
                                   id=account.uuid or '',
                                   locked='yes' if account.locked else 'no'))

--- a/pyethapp/tests/test_app.py
+++ b/pyethapp/tests/test_app.py
@@ -43,6 +43,13 @@ def test_no_such_command():
     result = runner.invoke(app.app, ['eat'])
     assert 'Error: No such command "eat"' in result.output, result.output
 
+def test_account_list():
+    runner = CliRunner()
+    result = runner.invoke(app.app, ['account', 'list'])
+    assert '#1' in result.output, result.output
+    assert 'Locked' in result.output, result.output
+
+    print(result.output)
 
 @pytest.mark.parametrize('content', ['', '<html/>', 'print "hello world"'])
 def test_non_dict_yaml_as_config_file(content):
@@ -117,3 +124,4 @@ if __name__ == '__main__':
     test_custom_config_file(('-C', 'myconfig.yaml'))
     test_custom_config_file(('-c', 'mygenesis.json'))
     test_custom_config_file(('-c', 'dict'))
+    test_account_list()


### PR DESCRIPTION
`pyethapp account list` was giving the following error:
```
/pyethapp/app.py", line 586, in list_accounts
    click.echo(fmt.format(i='#' + to_string(i + 1),
TypeError: must be str, not bytes
```

This is because, on python 3, ethereum.utils.to_string() will, when given an integer, return bytes (!).

ethereum.utils.to_string should probably also be fixed, or at least given a more correct name, but that's more work than I'm willing to take on right now.