### PR TITLE
Use the new eth-keyfile module, fixes #292

### DIFF
--- a/pyethapp/accounts.py
+++ b/pyethapp/accounts.py
@@ -2,6 +2,7 @@ from builtins import hex
 from builtins import object
 import json
 import os
+import eth_keyfile
 from random import SystemRandom
 import shutil
 from uuid import UUID
@@ -74,7 +75,7 @@ class Account(object):
         if not is_string(password):
             password = to_string(password)
 
-        keystore = keys.make_keystore_json(key, password)
+        keystore = eth_keyfile.create_keyfile_json(key, password)
         keystore['id'] = uuid
         return Account(keystore, password, path)
 
@@ -121,7 +122,9 @@ class Account(object):
                  account is locked)
         """
         if self.locked:
-            self._privkey = keys.decode_keystore_json(self.keystore, password)
+            if not is_string(password):
+                password = to_string(password)
+            self._privkey = eth_keyfile.decode_keyfile_json(self.keystore, password)
             self.locked = False
             self.address  # get address such that it stays accessible after a subsequent lock
 

--- a/pyethapp/tests/test_accounts.py
+++ b/pyethapp/tests/test_accounts.py
@@ -3,7 +3,7 @@ from builtins import str
 from past.utils import old_div
 import json
 from uuid import uuid4
-import ethereum.tools.keys
+import eth_keyfile.keyfile
 from ethereum.tools.keys import privtoaddr
 from ethereum.transactions import Transaction
 from ethereum.utils import (
@@ -14,7 +14,10 @@ from pyethapp.accounts import Account
 import pytest
 
 # reduce key derivation iterations
-ethereum.tools.keys.PBKDF2_CONSTANTS['c'] = 100
+def get_default_work_factor_for_kdf(kdf):
+    return 100
+eth_keyfile.keyfile.get_default_work_factor_for_kdf = \
+    get_default_work_factor_for_kdf
 
 
 @pytest.fixture()

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tinyrpc[gevent,httpclient,jsonext,websocket,wsgi]
 pycryptodome==3.4.6
 future
 https://github.com/ethereum/serpent/tarball/develop
+eth-keyfile


### PR DESCRIPTION
Use the new eth-keyfile module to encrypt/decrypt keyfile.
This makes it way faster to create and unlock accounts.
For instance with 100K PBKDF2 iteration rather than 100.
Running `pyethapp/tests/test_accounts.py` was outputing:
```
9 passed in 112.07 seconds
```
After the pull request it's now:
```
9 passed in 2.41 seconds
```